### PR TITLE
Adding the original formula for Gecode 3.7.3

### DIFF
--- a/gecode373.rb
+++ b/gecode373.rb
@@ -1,0 +1,12 @@
+require 'formula'
+
+class Gecode < Formula
+  homepage 'http://www.gecode.org/'
+  url 'http://www.gecode.org/download/gecode-3.7.3.tar.gz'
+  md5 '7a5cb9945e0bb48f222992f2106130ac'
+
+  def install
+    system "./configure", "--prefix=#{prefix}", "--disable-examples"
+    system "make install"
+  end
+end


### PR DESCRIPTION
Pulled directly from Jack Nagel's original contribution. Adding this to support anyone like me who needs to use an older version of Gecode in order to support environments with particular versions of the Chef DK.
